### PR TITLE
12_Twitter投稿テスト

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   get '/confirm/:id', to: 'twitter_posts#confirm', as: :confirm #この行を追加
-  resources :twitter_posts, only: %i(edit new create)
+  resources :twitter_posts
   devise_for :users
   root 'tweets#index'
 


### PR DESCRIPTION
## 変更前
Twitterに飛び、画像リンクを投稿するところまではできるが、
Heroku内の画像保存先URLによって共有されていない

## 変更後
URLを修正